### PR TITLE
Use standard promise name

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ exports.register = function (plugin, options, next) {
 
     sequelize
         .authenticate()
-        .complete(function(err) {
+        .then(function(err) {
             if (!!err) {
                 plugin.log(['hapi-sequelize', 'error'], 'Error connecting to database. ' + err);
                 return next(err);


### PR DESCRIPTION
At some point `complete` stopped working as it just throws an error now.
